### PR TITLE
chore: update nix fetchers

### DIFF
--- a/overlays/nixpkgs-local-vim-plugins.nix
+++ b/overlays/nixpkgs-local-vim-plugins.nix
@@ -9,23 +9,23 @@
       {
         nvim-cmp = pkgs.vimUtils.buildVimPlugin {
           name = "nvim-cmp";
-          version = "unstable-2026-03-25";
+          version = "unstable-2026-07-10";
           src = pkgs.fetchFromGitHub {
             owner = "hrsh7th";
             repo = "nvim-cmp";
-            rev = "a1d504892f2bc56c2e79b65c6faded2fd21f3eca";
-            sha256 = "0p2hr29k8cargnzrfnlfs2rnhyvxs83509n6992chani6bqcqdxv";
+            rev = "2ffe79f1f021def8dd1fcd81deb16f1bb0d989f3";
+            sha256 = "19z6cgwny9d3i1qzgppc3wxnjjpq4m95k8rnvif03m3gfl0hmpv0";
           };
           doCheck = false;
         };
         telescope-oil-nvim = pkgs.vimUtils.buildVimPlugin {
           name = "telescope-oil-nvim";
-          version = "unstable-2025-04-30";
+          version = "unstable-2026-05-22";
           src = pkgs.fetchFromGitHub {
             owner = "albenisolmos";
             repo = "telescope-oil.nvim";
-            rev = "5a86746e2803f67a98f9801ed4cf9c782d649a93";
-            sha256 = "09xw4s724gx6zcjk00af1iyczw35xjgq2w6k2z9fj5farl8wszq8";
+            rev = "997f0bcc2ec5237b9ad5a1e73d5baf4dfca3a687";
+            sha256 = "0zxk1zmr993s0rs942nv8i56np2ng560zifp667z88zlnfpmq5z0";
           };
           doCheck = false;
         };
@@ -53,34 +53,34 @@
         };
         opencode-nvim = pkgs.vimUtils.buildVimPlugin {
           name = "opencode-nvim";
-          version = "unstable-2026-05-11";
+          version = "unstable-2026-07-24";
           src = pkgs.fetchFromGitHub {
             owner = "NickvanDyke";
             repo = "opencode.nvim";
-            rev = "a89f9b90e2709f7350743bf2d38e80bc4fd5379d";
-            sha256 = "1cgwm1ld1gx5y5lb6x9808zyb84kjsd3yjx336hvh1j8xbr84mbl";
+            rev = "259ac3d3115cc16f29d6df9b7697add0c8b7cab4";
+            sha256 = "17ivwjprjd8pggp5kq3pipl20r8v2886vc7zshpjz598nq224df5";
           };
           doCheck = false;
         };
         jiejie-nvim = pkgs.vimUtils.buildVimPlugin {
           name = "jiejie-nvim";
-          version = "unstable-2026-06-13";
+          version = "unstable-2026-07-11";
           src = pkgs.fetchFromGitHub {
             owner = "jceb";
             repo = "jiejie.nvim";
-            rev = "e79982899358a15b535dcc901a61b331ebb3e922";
-            sha256 = "1fizn2rykf89plxsn7h6gpnf72y04gw0v4p5k893pcwvn05546j9";
+            rev = "29050c87d408e5dff0762eabe86aa8e2b3fff3f9";
+            sha256 = "0i9z7kgfhcgsscdj3zcfihbp46v6dnhzjgrpkkqv0bdz7nb28i1x";
           };
           doCheck = false;
         };
         jj-diffconflicts = pkgs.vimUtils.buildVimPlugin {
           name = "jj-diffconflicts";
-          version = "unstable-2026-03-22";
+          version = "unstable-2026-05-19";
           src = pkgs.fetchFromGitHub {
             owner = "rafikdraoui";
             repo = "jj-diffconflicts";
-            rev = "58163ae8fe7646179dfd7741206dd9a2b4cdadc0";
-            sha256 = "1gbvq4yx82rz3aqldrsnyjmlskznfxbnyc1axlzyh67d9siwwch8";
+            rev = "a2aa9a247b56d2c1a6f6be81bcf41c5450cc82ff";
+            sha256 = "0c2hl1ig27rvl25dwckpjb7j6gqz8cb7hihhnhf00is1d669qdij";
           };
           doCheck = false;
         };


### PR DESCRIPTION
Ran `update-nix-fetchgit` across `.nix` files via `just fetchgit`.

Bumps `rev` and `sha256` for `fetchFromGitHub` blocks, including the vim plugins overlay (`overlays/nixpkgs-local-vim-plugins.nix`).

Gated by `nix flake check --show-trace`.